### PR TITLE
Reduce history wildcard payloads and add runtime virtual-interface prefix filtering

### DIFF
--- a/pm_dashboard/data_logger.py
+++ b/pm_dashboard/data_logger.py
@@ -8,6 +8,8 @@ from .utils import log_error
 
 class DataLogger:
 
+    DEFAULT_VIRTUAL_INTERFACE_PREFIXES = ['veth', 'br-', 'docker', 'virbr', 'vmnet']
+
     @log_error
     def __init__(self, database=None, interval=1, log=None):
         self.log = log or logging.getLogger(app_name)
@@ -24,6 +26,7 @@ class DataLogger:
 
         self.db = database
         self.interval = interval
+        self.virtual_interface_prefixes = list(self.DEFAULT_VIRTUAL_INTERFACE_PREFIXES)
         
         self.status = {}
         self.__read_data__ = None
@@ -37,6 +40,15 @@ class DataLogger:
         self.interval = interval
 
     @log_error
+    def set_virtual_interface_prefixes(self, prefixes):
+        if isinstance(prefixes, list) and all(isinstance(prefix, str) for prefix in prefixes):
+            self.virtual_interface_prefixes = prefixes
+
+    def _get_exclude_prefixes(self):
+        prefixes = tuple(self.virtual_interface_prefixes)
+        return prefixes or None
+
+    @log_error
     def get_data(self):
         if self.__read_data__ is None:
             self.log.error("No read data function set")
@@ -45,8 +57,13 @@ class DataLogger:
         if data == {}:
             return {}
 
+        exclude_prefixes = self._get_exclude_prefixes()
         new_data = {}
         for key, value in data.items():
+            if key.startswith('ip_') or key.startswith('mac_'):
+                interface_name = key.split('_', 1)[1] if '_' in key else ''
+                if exclude_prefixes and interface_name.startswith(exclude_prefixes):
+                    continue
             if isinstance(value, bool):
                 value = int(value)
             elif isinstance(value, list):

--- a/pm_dashboard/database.py
+++ b/pm_dashboard/database.py
@@ -20,9 +20,47 @@ class Database:
         self.retention_days = retention_days
         self.influx_manually_started = False
         self.starting = False
+        self._field_keys_cache = {}
+        self._virtual_prefixes = self._build_virtual_field_prefixes(['veth', 'br-', 'docker', 'virbr', 'vmnet'])
 
         # initialize InfluxDB client
         self.client = InfluxDBClient(host='localhost', port=8086)
+
+    @staticmethod
+    def _build_virtual_field_prefixes(interface_prefixes):
+        return tuple(
+            f'{field_type}_{iface}'
+            for iface in interface_prefixes
+            for field_type in ('mac', 'ip')
+        )
+
+    @staticmethod
+    def _quote_identifier(identifier):
+        return '"' + identifier.replace('"', '\\"') + '"'
+
+    def set_virtual_prefixes(self, interface_prefixes):
+        if not isinstance(interface_prefixes, list) or not all(isinstance(prefix, str) for prefix in interface_prefixes):
+            return
+        self._virtual_prefixes = self._build_virtual_field_prefixes(interface_prefixes)
+        self._field_keys_cache.clear()
+
+    def get_stable_field_keys(self, measurement, max_age=60):
+        cached = self._field_keys_cache.get(measurement)
+        if cached and (time.time() - cached[0]) < max_age:
+            return cached[1]
+
+        try:
+            result = self.client.query(f'SHOW FIELD KEYS FROM "{measurement}"')
+            all_keys = [row['fieldKey'] for row in result.get_points()]
+            stable_keys = [
+                key for key in all_keys
+                if not key.startswith(self._virtual_prefixes)
+            ]
+            self._field_keys_cache[measurement] = (time.time(), stable_keys)
+            return stable_keys
+        except Exception as e:
+            self.log.warning(f"get_stable_field_keys failed for {measurement}: {e}")
+            return []
     
     def start(self):
         self.is_starting = True
@@ -208,7 +246,11 @@ class Database:
         if function not in ["mean", "sum", "min", "max", "count"]:
             self.log.error(f"Invalid function: {function}")
             return []
-        if keys != "*":
+        if keys == "*":
+            stable_keys = self.get_stable_field_keys(measurement)
+            if stable_keys:
+                keys = ",".join(self._quote_identifier(k) for k in stable_keys)
+        else:
             newKeys = []
             for k in keys.split(","):
                 newKeys.append(f'{function}("{k}") as "{k}"')
@@ -238,12 +280,18 @@ class Database:
         if not self.is_ready():
             self.log.error('Database is not ready')
             return []
+        if key == "*":
+            stable_keys = self.get_stable_field_keys(measurement)
+            if stable_keys:
+                key = ",".join(self._quote_identifier(k) for k in stable_keys)
 
         # Read data from last 1 second
         time_filter = "time < now() - 1s"
         query = f"SELECT {key} FROM {measurement} WHERE {time_filter} ORDER BY time DESC LIMIT {n}"
+
         with self.lock:
-            result = self.client.query(query)
+            for _ in range(3):
+                result = self.client.query(query)
 
         result = list(result.get_points())
         if n == 1:

--- a/pm_dashboard/pm_dashboard.py
+++ b/pm_dashboard/pm_dashboard.py
@@ -50,6 +50,7 @@ __app__.config['CORS_HEADERS'] = 'Content-Type'
 __device_info__ = {}
 __mqtt_connected__ = False
 __enable_history__ = False
+DEFAULT_VIRTUAL_INTERFACE_PREFIXES = ['veth', 'br-', 'docker', 'virbr', 'vmnet']
 
 __read_data__ = lambda: {}
 __get_ip_data__ = lambda: {}
@@ -300,8 +301,18 @@ def get_disk_list():
 @__app__.route(f'{__api_prefix__}/get-network-interface-list')
 @cross_origin()
 def get_network_interface_list():
-    interfaces = list(get_ips().keys())
+    prefixes = tuple(__config__.get('system', {}).get('virtual_interface_prefixes', DEFAULT_VIRTUAL_INTERFACE_PREFIXES))
+    interfaces = list(get_ips(exclude_prefixes=prefixes or None).keys())
     return {"status": True, "data": interfaces}
+
+@__app__.route(f'{__api_prefix__}/set-virtual-interface-prefixes', methods=['POST'])
+@cross_origin()
+def set_virtual_interface_prefixes():
+    prefixes = request.json.get("prefixes")
+    if not isinstance(prefixes, list) or not all(isinstance(prefix, str) for prefix in prefixes):
+        return {"status": False, "error": "[ERROR] prefixes must be a list of strings"}
+    __on_config_changed__({'system': {'virtual_interface_prefixes': prefixes}})
+    return {"status": True, "data": "OK"}
 
 @__app__.route(f'{__api_prefix__}/set-temperature-unit', methods=['POST'])
 @cross_origin()
@@ -740,6 +751,7 @@ def catch_all(path):
 
 class PMDashboard():
     def __init__(self, device_info=None, database='pm_dashboard', config=None, log=None, get_logger=None):
+        global __config__
         global __device_info__, __log_path__, __enable_history__
         global __data_logger__, __db__, __log__, __restart_service__
         global AVAILABLE_OLED_PAGES
@@ -757,20 +769,26 @@ class PMDashboard():
             self.log = log or logging.getLogger(__name__)
         __log__ = self.log
 
-        if 'enable_history' not in config['system']:
-            config['system']['enable_history'] = False
-        __enable_history__ = config['system']['enable_history']
-        if 'database_retention_days' not in config['system']:
-            config['system']['database_retention_days'] = 30
-        database_retention_days = config['system']['database_retention_days'] 
+        __config__ = config
+        if 'enable_history' not in __config__['system']:
+            __config__['system']['enable_history'] = False
+        if 'virtual_interface_prefixes' not in __config__['system']:
+            __config__['system']['virtual_interface_prefixes'] = list(DEFAULT_VIRTUAL_INTERFACE_PREFIXES)
+        __enable_history__ = __config__['system']['enable_history']
+        if 'database_retention_days' not in __config__['system']:
+            __config__['system']['database_retention_days'] = 30
+        database_retention_days = __config__['system']['database_retention_days'] 
 
         if __enable_history__:
             __db__ = Database(database, log=log, retention_days=database_retention_days)
         self.data_logger = DataLogger(
             database=__db__,
-            interval=config['system']['data_interval'],
+            interval=__config__['system']['data_interval'],
             log=self.log)
         __data_logger__ = self.data_logger
+        self.data_logger.set_virtual_interface_prefixes(__config__['system']['virtual_interface_prefixes'])
+        if __db__ is not None:
+            __db__.set_virtual_prefixes(__config__['system']['virtual_interface_prefixes'])
 
         self.started = False
 
@@ -806,8 +824,16 @@ class PMDashboard():
             self.data_logger.set_interval(config['data_interval'])
             patch['data_interval'] = config['data_interval']
         if 'database_retention_days' in config:
-            __db__.set_retention_days(config['database_retention_days'])
-            patch['database_retention_days'] = config['database_retention_days']
+            if __db__ is not None:
+                __db__.set_retention_days(config['database_retention_days'])
+                patch['database_retention_days'] = config['database_retention_days']
+        if 'virtual_interface_prefixes' in config:
+            prefixes = config['virtual_interface_prefixes']
+            if isinstance(prefixes, list) and all(isinstance(prefix, str) for prefix in prefixes):
+                self.data_logger.set_virtual_interface_prefixes(prefixes)
+                if __db__ is not None:
+                    __db__.set_virtual_prefixes(prefixes)
+                patch['virtual_interface_prefixes'] = prefixes
         return patch
 
     @log_error


### PR DESCRIPTION
Replaces #4 after rebasing fix/influx-select-star-and-virtual-prefix-config onto base v2.

## Depends On
- https://github.com/sunfounder/pm_auto/pull/15

## Related
- sunfounder/sf_rpi_status#1

## Problem
Wildcard history queries can return legacy transient keys, inflating payload size and latency on Docker hosts.

## Change
- `DataLogger`: add configurable `virtual_interface_prefixes` and apply exclusions when collecting `ip_*` and `mac_*`
- `Database`: resolve stable field keys and replace broad wildcard key expansion with filtered field selection
- `PMDashboard`: add `POST /api/v1.0/set-virtual-interface-prefixes` and propagate updates to logger/database
- `PMDashboard`: apply configured filtering in network interface listing endpoint

## Verification
- `python3 -m py_compile pm_dashboard/data_logger.py pm_dashboard/database.py pm_dashboard/pm_dashboard.py`
- Workspace diagnostics report no new errors in changed pm_dashboard files

## Impact
Reduces history query response size/latency and keeps virtual interface filtering configurable at runtime.
